### PR TITLE
Fix docker checks

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -43,21 +43,20 @@ $$ newgrp docker
 
 endef
 
-export GROUP_MESSAGE INSTALL_MESSAGE
+export DOCKER_MISSING NOT_IN_GROUP
 
 .DEFAULT_GOAL := commands
 
 check-for-docker:
-	@if ! command -v docker >/dev/null 2>&1 || ! grep -q '^docker:' /etc/group; then \
-	    echo >&2 "$$DOCKER_MISSING"; \
+	@if ! command -v docker >/dev/null 2>&1; then \
+	    echo "$$DOCKER_MISSING" >> /dev/stderr; \
 	    exit 1; \
 	fi
-	@if ! groups | grep -q '\bdocker\b'; then \
-	    echo "$$NOT_IN_GROUP"; \
+	@if grep -q '^docker:' /etc/group && ! groups | grep -q '\bdocker\b'; then \
+	    echo "$$NOT_IN_GROUP" >> /dev/stderr; \
 	    exit 1; \
 	fi
 
 %:
 	@${MAKE} --quiet check-for-docker
 	@${DEVRUN} $@
-


### PR DESCRIPTION
Ensure error messages are displaying properly, and accommodate for the fact that Macs dont have a docker group.

QA
--

On a mac, run:

``` bash
make -f Makefile.example check-for-docker
```

It should output nothing and return without an error.

Now, pretend to uninstall Docker by renaming the docker binary, and run the above command again.

``` bash
mv /usr/local/bin/docker /usr/local/bin/docker.moved
make -f Makefile.example check-for-docker
```
You should see:

``` bash
Error: Docker not installed
==

Please install Docker before continuing:
https://docs.docker.com/engine/installation/
```

Then replace your docker binary so docker works again:

``` bash
mv /usr/local/bin/docker.moved /usr/local/bin/docker
```